### PR TITLE
Link appointment booking portal from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,7 +596,7 @@
           <div class="step-num">2</div>
           <div>
             <h3>Connect your accounts</h3>
-            <p>Pal-E sends you one-click OAuth links right in the chat. Tap to connect Notion or LinkedIn instantly. Gmail and Calendar are in early access — <a href="#google-access" style="color: var(--accent-text);">request a slot</a> and get a personal onboarding walkthrough. All tokens are encrypted and stored on isolated infrastructure.</p>
+            <p>Pal-E sends you one-click OAuth links right in the chat. Tap to connect Notion or LinkedIn instantly. Gmail and Calendar are in early access — <a href="#google-access" style="color: var(--accent-text);">book an onboarding call</a> to get set up. All tokens are encrypted and stored on isolated infrastructure.</p>
           </div>
         </div>
         <div class="step">

--- a/index.html
+++ b/index.html
@@ -536,13 +536,13 @@
           <div class="icon">📧</div>
           <h3>Gmail <span class="early-badge">Early Access</span></h3>
           <p>Read, search, and draft emails. Summarize threads. Never miss an important message.</p>
-          <p class="early-note">Requires onboarding appointment — limited spots available.</p>
+          <p class="early-note"><a href="#google-access" style="color: var(--amber);">Book an onboarding call</a> — limited spots available.</p>
         </div>
         <div class="tool-card tool-card-early">
           <div class="icon">📅</div>
           <h3>Google Calendar <span class="early-badge">Early Access</span></h3>
           <p>Check your schedule, create events, find free slots. Stay on top of your day.</p>
-          <p class="early-note">Requires onboarding appointment — limited spots available.</p>
+          <p class="early-note"><a href="#google-access" style="color: var(--amber);">Book an onboarding call</a> — limited spots available.</p>
         </div>
         <div class="tool-card">
           <div class="icon">💼</div>
@@ -573,10 +573,10 @@
             <p>During setup, you will see a Google warning — this is expected for early access apps. Your onboarding guide walks you through it.</p>
           </div>
         </div>
-        <a href="https://t.me/personal_assistant_ldraney_bot" class="btn btn-google-access" target="_blank" rel="noopener noreferrer">
-          Request Google Access
+        <a href="https://pal-e-appointment.tail5b443a.ts.net" class="btn btn-google-access" target="_blank" rel="noopener noreferrer">
+          Book Onboarding Call
         </a>
-        <p class="ga-note">Message the Pal-E Telegram bot to request your early access slot. You will be booked for a short onboarding call.</p>
+        <p class="ga-note">Pick a time that works for you. We'll walk you through connecting your Google accounts in a quick 1-on-1 call.</p>
       </div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -207,6 +207,10 @@
       margin-top: 8px;
       line-height: 1.4;
     }
+    .tool-card-early .early-note a {
+      color: var(--amber);
+      text-decoration: underline;
+    }
 
     /* Google Early Access section */
     .google-access {
@@ -536,13 +540,13 @@
           <div class="icon">📧</div>
           <h3>Gmail <span class="early-badge">Early Access</span></h3>
           <p>Read, search, and draft emails. Summarize threads. Never miss an important message.</p>
-          <p class="early-note"><a href="#google-access" style="color: var(--amber);">Book an onboarding call</a> — limited spots available.</p>
+          <p class="early-note"><a href="#google-access">Book an onboarding call</a> — limited spots available.</p>
         </div>
         <div class="tool-card tool-card-early">
           <div class="icon">📅</div>
           <h3>Google Calendar <span class="early-badge">Early Access</span></h3>
           <p>Check your schedule, create events, find free slots. Stay on top of your day.</p>
-          <p class="early-note"><a href="#google-access" style="color: var(--amber);">Book an onboarding call</a> — limited spots available.</p>
+          <p class="early-note"><a href="#google-access">Book an onboarding call</a> — limited spots available.</p>
         </div>
         <div class="tool-card">
           <div class="icon">💼</div>
@@ -558,7 +562,7 @@
     <div class="container">
       <div class="google-access-inner">
         <h2>Google Integrations — Early Access</h2>
-        <p class="ga-subtitle">Gmail and Google Calendar are available to a limited group of early adopters. Book a quick onboarding call to get set up.</p>
+        <p class="ga-subtitle">Gmail and Google Calendar are available to a limited group of early adopters. Book an onboarding call to get set up.</p>
         <div class="ga-features">
           <div class="ga-feature">
             <h4>Limited spots</h4>

--- a/index.html
+++ b/index.html
@@ -716,7 +716,7 @@
           </div>
           <div class="at-feature">
             <h3>Custom integrations</h3>
-            <p>Need a tool that isn't listed? Message the bot to discuss building a custom MCP server for your workflow.</p>
+            <p>Need a tool that isn't listed? Book a call to discuss building a custom MCP server for your workflow.</p>
           </div>
         </div>
         <a href="https://pal-e-appointment.tail5b443a.ts.net" class="btn btn-alpha" target="_blank" rel="noopener noreferrer">

--- a/index.html
+++ b/index.html
@@ -319,6 +319,7 @@
     }
     .step h3 { font-size: 1rem; margin-bottom: 4px; }
     .step p { color: var(--muted); font-size: 0.9rem; }
+    .step a { color: var(--accent-text); }
 
     /* Why section */
     .why {
@@ -600,7 +601,7 @@
           <div class="step-num">2</div>
           <div>
             <h3>Connect your accounts</h3>
-            <p>Pal-E sends you one-click OAuth links right in the chat. Tap to connect Notion or LinkedIn instantly. Gmail and Calendar are in early access — <a href="#google-access" style="color: var(--accent-text);">book an onboarding call</a> to get set up. All tokens are encrypted and stored on isolated infrastructure.</p>
+            <p>Pal-E sends you one-click OAuth links right in the chat. Tap to connect Notion or LinkedIn instantly. Gmail and Calendar are in early access — <a href="#google-access">book an onboarding call</a> to get set up. All tokens are encrypted and stored on isolated infrastructure.</p>
           </div>
         </div>
         <div class="step">


### PR DESCRIPTION
## Summary

- Replace "Request Google Access" Telegram CTA with direct "Book Onboarding Call" link to `pal-e-appointment` portal
- Update tool card early-access notes with clickable anchor links to the booking section
- Update supporting copy to reflect self-serve booking flow

Closes #20

## Test plan

- [ ] Verify "Book Onboarding Call" button links to `https://pal-e-appointment.tail5b443a.ts.net`
- [ ] Verify Gmail and Calendar tool card links scroll to #google-access section
- [ ] Check mobile responsiveness of updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)